### PR TITLE
Remove: 動画のランダム表示を削除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
 
   def set_search
     @q = Video.ransack(params[:q])
-    videos = @q.result(distinct: true).shuffle
+    videos = @q.result(distinct: true)
     @videos = Kaminari.paginate_array(videos).page(params[:page])
   end
 end


### PR DESCRIPTION
## 概要

- 動画をランダム表示すると、「もっと見る」を押したときに同じ動画が表示されるため、`shuffleメソッド`を削除。