### PR TITLE
システムスペック

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,5 +73,12 @@ group :development do
   gem 'rubocop-performance', require: false
 end
 
+group :test do
+  # Adds support for Capybara system testing and selenium driver
+  gem 'capybara'
+  # Easy installation and use of web drivers to run system tests with browsers
+  gem 'webdrivers'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -71,6 +73,16 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
+    capybara (3.36.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
@@ -123,6 +135,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
@@ -137,6 +150,7 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    public_suffix (4.0.6)
     puma (4.3.10)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -223,6 +237,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -236,6 +251,10 @@ GEM
     seed-fu (2.3.9)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
+    selenium-webdriver (4.1.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -270,6 +289,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.0.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webpacker (4.3.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -277,6 +300,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.5.1)
 
 PLATFORMS
@@ -288,6 +313,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   bullet
   byebug
+  capybara
   dotenv-rails
   factory_bot_rails
   gon
@@ -313,6 +339,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
+  webdrivers
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:line_user_id, 'line_user_id_1')
+  end
+end

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :video do
-    sequence(:youtube_id, 'yid_1')
-    address { 'tokyo' }
-    sauna { 'karumaru' }
+    sequence(:youtube_id, 'iTSsv7AZ8dw')
+    address { '東京' }
+    sauna { 'かるまる' }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome
+  end
+end

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe "Bookmarks", type: :system do
+  let(:user) { create(:user) }
+  let(:video) { create(:video) }
+
+  describe 'ログイン後' do
+    before do
+      # sessionにUserIDを返し、ログインしたことにする
+      allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(user_id: user.id)
+    end
+    describe '動画詳細ページにアクセス' do
+      before do
+        visit video_path(video)
+      end
+      context '「ハート」ボタンを押す' do
+        before do
+          find('.fa-heart').click
+        end
+        it 'いいねページに動画が追加されている' do
+          visit bookmarks_videos_path
+          expect(page).to have_content video.sauna
+        end
+      end
+    end
+
+    describe '動画一覧ページにアクセス' do
+      before do
+        video
+        visit videos_path
+      end
+      context '最初にある動画の「ハート」ボタンを押す' do
+        before do
+          page.first('.fa-heart').click
+        end
+        it 'いいねページに動画が追加されている' do
+          visit bookmarks_videos_path
+          expect(page).to have_content video.sauna
+        end
+      end
+    end
+  end
+end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Profiles', type: :system do
+  let(:user) { create(:user) }
+
+  describe 'プロフィールページにアクセス' do
+    before do
+      # sessionにUserIDを返し、ログインしたことにする
+      allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(user_id: user.id)
+      visit profile_path
+    end
+    it '動画視聴状況が表示される' do
+      expect(page).to have_content('動画視聴状況')
+    end
+  end
+end

--- a/spec/system/videos_spec.rb
+++ b/spec/system/videos_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "Videos", type: :system do
+  describe 'ログイン前' do
+    context '動画一覧ページにアクセス' do
+      it 'アクセスが成功する' do
+        visit videos_path
+        expect(page).to have_content('動画一覧')
+      end
+    end
+  end
+end

--- a/spec/system/videos_spec.rb
+++ b/spec/system/videos_spec.rb
@@ -1,11 +1,61 @@
 require 'rails_helper'
 
-RSpec.describe "Videos", type: :system do
-  describe 'ログイン前' do
-    context '動画一覧ページにアクセス' do
-      it 'アクセスが成功する' do
-        visit videos_path
-        expect(page).to have_content('動画一覧')
+RSpec.describe 'Videos', type: :system do
+  let(:video) { create(:video) }
+
+  describe '動画詳細ページにアクセス' do
+    before do
+      visit video_path(video)
+    end
+    it '動画が詳細情報が表示される' do
+      expect(page).to have_content video.sauna
+      expect(current_path).to eq video_path(video)
+    end
+  end
+
+  describe '動画一覧ページにアクセス' do
+    before do
+      visit videos_path
+    end
+
+    it '動画一覧が表示される' do
+      expect(page).to have_content('動画一覧')
+    end
+
+    context '地名を検索フォームに入力' do
+      before do
+        fill_in 'q[sauna_or_address_cont]', with: video.address
+        find('.search-btn').click
+      end
+
+      it '該当する動画が表示される' do
+        expect(page).to have_content video.address
+        expect(current_path).to eq videos_path
+      end
+    end
+
+    context '施設名を検索フォームに入力' do
+      before do
+        fill_in 'q[sauna_or_address_cont]', with: video.sauna
+        find('.search-btn').click
+      end
+
+      it '該当する動画が表示される' do
+        expect(page).to have_content video.sauna
+        expect(current_path).to eq videos_path
+      end
+    end
+
+    context '該当しない文字を検索フォームに入力' do
+      before do
+        video
+        fill_in 'q[sauna_or_address_cont]', with: 'あいうえお'
+        find('.search-btn').click
+      end
+
+      it '動画が表示されない' do
+        expect(page).to have_content('該当するサウナ動画は見つかりませんでした。')
+        expect(current_path).to eq videos_path
       end
     end
   end

--- a/spec/system/videos_spec.rb
+++ b/spec/system/videos_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Videos', type: :system do
     before do
       visit video_path(video)
     end
-    it '動画が詳細情報が表示される' do
+    it '動画の詳細情報が表示される' do
       expect(page).to have_content video.sauna
       expect(current_path).to eq video_path(video)
     end

--- a/spec/system/watches_spec.rb
+++ b/spec/system/watches_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "Watches", type: :system do
+  let(:user) { create(:user) }
+  let(:video) { create(:video) }
+
+  describe 'ログイン後' do
+    before do
+      # sessionにUserIDを返し、ログインしたことにする
+      allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(user_id: user.id)
+    end
+    describe '動画詳細ページにアクセス' do
+      before do
+        visit video_path(video)
+      end
+      context '「視聴済にする」ボタンを押す' do
+        before do
+          click_link '視聴済にする'
+        end
+        it '「視聴済」になり、チェックマークが付与されている' do
+          expect(page).to have_css('.fa-circle-check')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

- rails new実行時にskip-testしたため、capybaraとwebdriversのGemをインストール。

rails6の場合、skip-testしないと以下がインストールされる。
```
# Gemfile
group :test do
  # Adds support for Capybara system testing and selenium driver
  gem 'capybara', '>= 2.15'
  gem 'selenium-webdriver'
  # Easy installation and use of web drivers to run system tests with browsers
  gem 'webdrivers'
end
```

## 参考記事
https://qiita.com/shogo-1988/items/1a59fd623fb8072f7381