### PR TITLE
Fix: LINEのプロフィール情報取得できるよう修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,6 @@ gem 'seed-fu'
 gem 'ransack'
 # ページネーション実装のためのgem
 gem 'kaminari'
-# 日本語化対応
-gem 'rails-i18n', '~> 6.0'
 # RailsとJavascriptの連携
 gem 'gon'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,9 +179,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    rails-i18n (6.0.0)
-      i18n (>= 0.7, < 2)
-      railties (>= 6.0.0, < 7)
     railties (6.0.4.1)
       actionpack (= 6.0.4.1)
       activesupport (= 6.0.4.1)
@@ -325,7 +322,6 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.4)
-  rails-i18n (~> 6.0)
   ransack
   rspec-rails (~> 5.0.0)
   rubocop

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - JavaScript
 - LIFF(LINE Front-end Framework)
 - LINE Messaging API
+- RSpec
 
 ### 主要Gem
 - line-bot-api (LINE通知)
@@ -46,4 +47,4 @@
 - rubocop (Rubyの静的コード解析)
 
 ## ER図
-![ER図](https://user-images.githubusercontent.com/83480020/159709657-386f5af7-d906-416c-9579-c736052b57fc.png)
+![ER図](https://user-images.githubusercontent.com/83480020/160855835-2bbea32b-e800-48bc-bcbd-eaa42b479a03.png)

--- a/app/controllers/line_bots_controller.rb
+++ b/app/controllers/line_bots_controller.rb
@@ -2,30 +2,21 @@ require 'json'
 
 class LineBotsController < ApplicationController
   skip_before_action :login_required
-  # CSRF対策を無効化する設定
+  # CSRF対策を無効化
   protect_from_forgery except: [:callback]
 
   def callback
-    # LINEから送信されたメッセージ内容を文字列に変換し変数にする
     body = request.body.read
-    # ヘッダーに格納された署名の情報を変数にする
     signature = request.env['HTTP_X_LINE_SIGNATURE']
-    # validate_signatureメソッドは署名の検証している
-    # 引数のbodyは文字列で渡す必要がある
     return head :bad_request unless client.validate_signature(body, signature)
 
-    # 変数bodyのevent以下の文字列を配列化して取得
     events = client.parse_events_from(body)
     events.each do |event|
-      # eventがLine::Bot::Event::Messageクラスかどうかを評価
       case event
       when Line::Bot::Event::Message
-        # textであるかどうかを評価
         case event.type
         when Line::Bot::Event::MessageType::Text
-
           message = event.message['text']
-          # JSONファイルに文字列[message]のjsonデータがあるか検証
           if api_response[message]
             client.reply_message(event['replyToken'], api_response[message])
           else
@@ -39,8 +30,6 @@ class LineBotsController < ApplicationController
 
   private
 
-  # LINE Messaging API SDKの機能を使うには自身の「チャンネルシークレット」と「チャンネルアクセストークン」を設定する必要がある。
-  # callbackメソッドで複数回呼び出されるため、1回目のみ右辺を代入するようにしている
   def client
     @client ||= Line::Bot::Client.new do |config|
       config.channel_secret = ENV['LINE_CHANNEL_SECRET']
@@ -48,9 +37,7 @@ class LineBotsController < ApplicationController
     end
   end
 
-  # public/jsonにあるJSONファイルを呼びだす
   def api_response
-    # モジュールparseは文字列しかRubyオブジェクトに変換できない
     @json ||= open('public/json/line-bot.json').read
     JSON.parse(@json)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,20 +5,17 @@ class UsersController < ApplicationController
 
   def new; end
 
-  # JSから/usersのmethod: 'POST'でリクエストされると実行する
+  # JSからリクエストされると実行
   def create
-    # JSからのbodyに代入されたidTokenを取得
     id_token = params[:idToken]
     channel_id = ENV['LIFF_CHANNEL_ID']
-    # HTTPリクエスト
     params = { 'id_token' => id_token, 'client_id' => channel_id }
     uri = URI.parse('https://api.line.me/oauth2/v2.1/verify')
-    # 検証が成功すると、変数resにユーザーの情報が代入される
+    # IDトークンを検証し、ユーザーの情報を取得
     res = Net::HTTP.post_form(uri, params)
     # LINEユーザーIDを取得
     line_user_id = JSON.parse(res.body)['sub']
     user = User.find_by(line_user_id: line_user_id)
-    # DBにuserが保存されていなければユーザー登録する
     user = User.create!(line_user_id: line_user_id) if user.nil?
     session[:user_id] = user.id
   end

--- a/app/javascript/packs/profiles/show.js
+++ b/app/javascript/packs/profiles/show.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     liffId: gon.liff_id
   })
   .then(() => {
-  // ログインユーザーのプロフィール情報を取り出す
+    // ログインユーザーのプロフィール情報を取り出す
     liff.getProfile()
     .then(profile => {
       // アイコン設定していなければ取得しない。

--- a/app/javascript/packs/profiles/show.js
+++ b/app/javascript/packs/profiles/show.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const name = document.getElementById('name');
   const picture = document.getElementById('picture');
-  // LIFFアプリを初期化。初期化するとSDKのメソッドを実行できる。
+  // LIFFのメソッドを実行できるようにする
   liff.init({
     liffId: gon.liff_id
   })
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // ログインユーザーのプロフィール情報を取り出す
     liff.getProfile()
     .then(profile => {
-      // アイコン設定していなければ取得しない。
+      // アイコン設定していなければ取得しない
       if (typeof profile.pictureUrl !== 'undefined') {
         picture.src = profile.pictureUrl
       }
@@ -26,8 +26,8 @@ document.addEventListener('DOMContentLoaded', () => {
     send.style.display ="none";
     modal.style.display ="none";
   }
-  // ターゲットピッカーを表示
   send.addEventListener('click', () => {
+    // ターゲットピッカーを表示
     liff.shareTargetPicker([
       message = {
         "type": "template",

--- a/app/javascript/packs/profiles/show.js
+++ b/app/javascript/packs/profiles/show.js
@@ -5,14 +5,16 @@ document.addEventListener('DOMContentLoaded', () => {
   liff.init({
     liffId: gon.liff_id
   })
+  .then(() => {
   // ログインユーザーのプロフィール情報を取り出す
-  liff.getProfile()
-  .then(profile => {
-    // アイコン設定していなければ取得しない。
-    if (typeof profile.pictureUrl !== 'undefined') {
-      picture.src = profile.pictureUrl
-    }
-    name.innerText = profile.displayName
+    liff.getProfile()
+    .then(profile => {
+      // アイコン設定していなければ取得しない。
+      if (typeof profile.pictureUrl !== 'undefined') {
+        picture.src = profile.pictureUrl
+      }
+      name.innerText = profile.displayName
+    })
   })
   const send = document.getElementById('send-message');
   const modal = document.getElementById('modal');

--- a/app/javascript/packs/users/new.js
+++ b/app/javascript/packs/users/new.js
@@ -1,30 +1,27 @@
 document.addEventListener('DOMContentLoaded', () => {
   const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-  // LIFFアプリを初期化。初期化するとSDKのメソッドを実行できる。
+  // LIFFのメソッドを実行できるようにする
   liff.init({
     liffId: gon.liff_id
   })
   .then(() => {
     if (!liff.isLoggedIn()) {
-      // 開発時、外部ブラウザからログインするために利用
+      // 外部ブラウザからでもログイン処理を行う
       liff.login()
     }
   })
-  // ユーザーのIDトークンを取得
   .then(() => {
+    // ユーザーのIDトークンを取得
     const idToken = liff.getIDToken()
-    // railsがパラメータとしてidTokenを受け取れるよう、変数bodyに代入
     const body =`idToken=${idToken}`
     const request = new Request('/users', {
       headers: {
-        // 検証するために必須なリクエストヘッダー
         'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
         'X-CSRF-Token': token
       },
       method: 'POST',
       body: body
     });
-    // railsにリクエストし、レスポンスを取得
     fetch(request)
     .then(() => {
       window.location = '/videos'

--- a/app/javascript/packs/videos/show.js
+++ b/app/javascript/packs/videos/show.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   const send = document.getElementById('send-message');
   const modal = document.getElementById('modal');
-  // LIFFプラウザ以外、押すとターゲットピッカーが表示されるボタンを非表示
+  // LIFFプラウザ以外、ターゲットピッカー非表示
   if (liff.isInClient()) {
     send.style.display ="display";
     modal.style.display ="display";
@@ -25,12 +25,12 @@ document.addEventListener('DOMContentLoaded', () => {
     modal.style.display ="none";
   }
   const video_url = `https://www.sauna-iko.net/videos/${gon.video.id}`;
-  // ターゲットピッカーを表示
   send.addEventListener('click', () => {
-    // LIFFアプリを初期化。初期化するとSDKのメソッドを実行できる。
+    // LIFFのメソッドを実行できるようにする
     liff.init({
       liffId: gon.liff_id
     })
+    // ターゲットピッカーを表示
     liff.shareTargetPicker([
       message = {
         "type": "template",

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,5 @@ module SaunaLinebot
     end
 
     config.time_zone = 'Asia/Tokyo'
-    config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
   end
 end

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Bookmarks", type: :system do
+RSpec.describe 'Bookmarks', type: :system do
   let(:user) { create(:user) }
   let(:video) { create(:video) }
 

--- a/spec/system/watches_spec.rb
+++ b/spec/system/watches_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Watches", type: :system do
+RSpec.describe 'Watches', type: :system do
   let(:user) { create(:user) }
   let(:video) { create(:video) }
 


### PR DESCRIPTION
## 概要
現状、LINEのプロフィール情報を取得する`liff.getProfile()`が発火していなかった。
修正後、`liff.getProfile()`は発火し、プロフィールアイコンと名前を表示する。
