### PR TITLE
APIのロジックをValue Objectに分離

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,10 +8,7 @@ class Admin::UsersController < Admin::BaseController
   def create
     id_token = params[:idToken]
     channel_id = ENV['ADMIN_LIFF_CHANNEL_ID']
-    params = { 'id_token' => id_token, 'client_id' => channel_id }
-    uri = URI.parse('https://api.line.me/oauth2/v2.1/verify')
-    res = Net::HTTP.post_form(uri, params)
-    line_user_id = JSON.parse(res.body)['sub']
+    line_user_id = LiffInterface.new(id_token, channel_id).get_user_id
     user = User.find_by(line_user_id: line_user_id)
     session[:user_id] = user.id
   end

--- a/app/controllers/line_bots_controller.rb
+++ b/app/controllers/line_bots_controller.rb
@@ -1,44 +1,10 @@
-require 'json'
-
 class LineBotsController < ApplicationController
   skip_before_action :login_required
   # CSRF対策を無効化
   protect_from_forgery except: [:callback]
 
   def callback
-    body = request.body.read
-    signature = request.env['HTTP_X_LINE_SIGNATURE']
-    return head :bad_request unless client.validate_signature(body, signature)
-
-    events = client.parse_events_from(body)
-    events.each do |event|
-      case event
-      when Line::Bot::Event::Message
-        case event.type
-        when Line::Bot::Event::MessageType::Text
-          message = event.message['text']
-          if api_response[message]
-            client.reply_message(event['replyToken'], api_response[message])
-          else
-            client.reply_message(event['replyToken'], api_response['予想しないメッセージ'])
-          end
-        end
-      end
-    end
+    LineBotInterface.new(request).reply
     head :ok
-  end
-
-  private
-
-  def client
-    @client ||= Line::Bot::Client.new do |config|
-      config.channel_secret = ENV['LINE_CHANNEL_SECRET']
-      config.channel_token = ENV['LINE_CHANNEL_TOKEN']
-    end
-  end
-
-  def api_response
-    @json ||= open('public/json/line-bot.json').read
-    JSON.parse(@json)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,8 @@ class UsersController < ApplicationController
   # JSからリクエストされると実行
   def create
     id_token = params[:idToken]
-    line_user_id = LiffInterface.new(id_token).get_user_id
+    channel_id = ENV['LIFF_CHANNEL_ID']
+    line_user_id = LiffInterface.new(id_token, channel_id).get_user_id
     user = User.find_by(line_user_id: line_user_id)
     user = User.create!(line_user_id: line_user_id) if user.nil?
     session[:user_id] = user.id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,13 +8,7 @@ class UsersController < ApplicationController
   # JSからリクエストされると実行
   def create
     id_token = params[:idToken]
-    channel_id = ENV['LIFF_CHANNEL_ID']
-    params = { 'id_token' => id_token, 'client_id' => channel_id }
-    uri = URI.parse('https://api.line.me/oauth2/v2.1/verify')
-    # IDトークンを検証し、ユーザーの情報を取得
-    res = Net::HTTP.post_form(uri, params)
-    # LINEユーザーIDを取得
-    line_user_id = JSON.parse(res.body)['sub']
+    line_user_id = LiffInterface.new(id_token).response
     user = User.find_by(line_user_id: line_user_id)
     user = User.create!(line_user_id: line_user_id) if user.nil?
     session[:user_id] = user.id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   # JSからリクエストされると実行
   def create
     id_token = params[:idToken]
-    line_user_id = LiffInterface.new(id_token).response
+    line_user_id = LiffInterface.new(id_token).get_user_id
     user = User.find_by(line_user_id: line_user_id)
     user = User.create!(line_user_id: line_user_id) if user.nil?
     session[:user_id] = user.id

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -10,8 +10,7 @@ class VideosController < ApplicationController
     @video = Video.find(params[:id])
     gon.video = @video
     # Youtube動画情報を取得
-    oembed_url = URI.parse("https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=#{@video.youtube_id}&format=json")
-    @youtube = JSON.parse(Net::HTTP.get_response(oembed_url).body)
+    @youtube = OembedInterface.new(@video).response
   end
 
   def bookmarks

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -9,11 +9,9 @@ class VideosController < ApplicationController
   def show
     @video = Video.find(params[:id])
     gon.video = @video
-    # Youtube動画のタイトルとチャンネル名を取得
+    # Youtube動画情報を取得
     oembed_url = URI.parse("https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=#{@video.youtube_id}&format=json")
-    res = Net::HTTP.get_response(oembed_url)
-    @title = JSON.parse(res.body)['title']
-    @author_name = JSON.parse(res.body)['author_name']
+    @youtube = JSON.parse(Net::HTTP.get_response(oembed_url).body)
   end
 
   def bookmarks

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def title(youtube)
+    youtube['title']
+  end
+
+  def author_name(youtube)
+    youtube['author_name']
+  end
 end

--- a/app/interfaces/liff_interface.rb
+++ b/app/interfaces/liff_interface.rb
@@ -1,13 +1,13 @@
 class LiffInterface
-  attr_reader :id_token
+  attr_reader :id_token, :channel_id
 
-  def initialize(id_token)
+  def initialize(id_token, channel_id)
     @id_token = id_token
+    @channel_id = channel_id
   end
 
   def get_user_id
-    channel_id = ENV['LIFF_CHANNEL_ID']
-    params = { 'id_token' => @id_token, 'client_id' => channel_id }
+    params = { 'id_token' => @id_token, 'client_id' => @channel_id }
     uri = URI.parse('https://api.line.me/oauth2/v2.1/verify')
     # IDトークンを検証し、ユーザーの情報を取得
     res = Net::HTTP.post_form(uri, params)

--- a/app/interfaces/liff_interface.rb
+++ b/app/interfaces/liff_interface.rb
@@ -1,0 +1,17 @@
+class LiffInterface
+  attr_reader :id_token
+
+  def initialize(id_token)
+    @id_token = id_token
+  end
+
+  def response
+    channel_id = ENV['LIFF_CHANNEL_ID']
+    params = { 'id_token' => @id_token, 'client_id' => channel_id }
+    uri = URI.parse('https://api.line.me/oauth2/v2.1/verify')
+    # IDトークンを検証し、ユーザーの情報を取得
+    res = Net::HTTP.post_form(uri, params)
+    # LINEユーザーIDを取得
+    JSON.parse(res.body)['sub']
+  end
+end

--- a/app/interfaces/liff_interface.rb
+++ b/app/interfaces/liff_interface.rb
@@ -5,7 +5,7 @@ class LiffInterface
     @id_token = id_token
   end
 
-  def response
+  def get_user_id
     channel_id = ENV['LIFF_CHANNEL_ID']
     params = { 'id_token' => @id_token, 'client_id' => channel_id }
     uri = URI.parse('https://api.line.me/oauth2/v2.1/verify')

--- a/app/interfaces/line_bot_interface.rb
+++ b/app/interfaces/line_bot_interface.rb
@@ -1,0 +1,43 @@
+class LineBotInterface
+  attr_reader :request
+
+  def initialize(request)
+    @request = request
+  end
+
+  def reply
+    body = @request.body.read
+    signature = @request.env['HTTP_X_LINE_SIGNATURE']
+    return head :bad_request unless client.validate_signature(body, signature)
+
+    events = client.parse_events_from(body)
+    events.each do |event|
+      case event
+      when Line::Bot::Event::Message
+        case event.type
+        when Line::Bot::Event::MessageType::Text
+          message = event.message['text']
+          if json_message[message]
+            client.reply_message(event['replyToken'], json_message[message])
+          else
+            client.reply_message(event['replyToken'], json_message['予想しないメッセージ'])
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def client
+    @client ||= Line::Bot::Client.new do |config|
+      config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+    end
+  end
+
+  def json_message
+    json ||= open('public/json/line-bot.json').read
+    JSON.parse(json)
+  end
+end

--- a/app/interfaces/oembed_interface.rb
+++ b/app/interfaces/oembed_interface.rb
@@ -1,0 +1,13 @@
+class OembedInterface
+  attr_reader :video
+
+  def initialize(video)
+    @video = video
+  end
+
+  def response
+    oembed_url = URI.parse("https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=#{@video.youtube_id}&format=json")
+    res = Net::HTTP.get_response(oembed_url)
+    JSON.parse(res.body)
+  end
+end

--- a/app/views/videos/show.html.slim
+++ b/app/views/videos/show.html.slim
@@ -9,11 +9,13 @@
       .ratio.ratio-16x9
         / 以下の#playerはyoutubeのiframeに入れ替わる。
         #player
-      h5.my-2 #{@title}
+      h5.my-2
+        = title(@youtube)
       hr.my-1
       .row
         .col-10.px-3
-          p.mb-0 #{@author_name}
+          p.mb-0
+            = author_name(@youtube)
         .col-2
           = link_to "https://twitter.com/share?url=#{request.url}/&text=#{@video.sauna} - サウナイコ&hashtags=サウナイコ,サウナ", target: '_blank', rel: 'noopener noreferrer' do
             i.fa-brands.fa-twitter.fa-lg style='color: #3399FF;'

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Video, type: :model do
         video = create(:video)
         video_added_youtube_id = build(:video, youtube_id: video.youtube_id)
         expect(video_added_youtube_id).to be_invalid
-        expect(video_added_youtube_id.errors.full_messages).to eq ["Youtube has already been taken"]
+        expect(video_added_youtube_id.errors.full_messages).to eq ['Youtube has already been taken']
       end
     end
   end


### PR DESCRIPTION
## 概要

1. youtubeのタイトルとyoutuber名の表示は、ユーザインタフェースためだけのロジック（プレゼンテーション層）であるため、`ヘルパー`に移行。
2. 3つのAPI（oEmbed,LIFF,Linebot）の処理を`Interfacesディレクトリ`に移行。3つの処理は読み取りの処理のため、変数を`attr_reader`で定義。